### PR TITLE
Allow alternate (non-base64) data-uri encodings

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,10 @@ module.exports = function(content) {
 		limit = parseInt(query.limit, 10);
 	}
 	var mimetype = query.mimetype || query.minetype || mime.lookup(this.resourcePath);
+	var encoding = query.encoding || 'base64';
 	if(limit <= 0 || content.length < limit) {
-		return "module.exports = " + JSON.stringify("data:" + (mimetype ? mimetype + ";" : "") + "base64," + content.toString("base64"));
+		var data = encoding + "," + content.toString(encoding);
+		return "module.exports = " + JSON.stringify("data:" + (mimetype ? mimetype + ";" : "") + data);
 	} else {
 		var fileLoader = require("file-loader");
 		return fileLoader.call(this, content);


### PR DESCRIPTION
Based on https://css-tricks.com/probably-dont-base64-svg/

I'm using this to inline SVGs in CSS, so they don't need to be base64 encoded. This change adds an `encoding` param to the query, defaulting to `base64` but allowing `utf8` and other arbitrary values. The proposed approach works well with [Buffer.toString()](https://nodejs.org/api/buffer.html#buffer_buf_tostring_encoding_start_end)'s encoding argument.
